### PR TITLE
Removes latent deterministic params from slac gin

### DIFF
--- a/slac/agents/slac/configs/slac.gin
+++ b/slac/agents/slac/configs/slac.gin
@@ -6,8 +6,6 @@ SlacAgent.critic_input_stop_gradient = True
 # Parameters for ModelDistributionNetwork:
 # ==============================================================================
 ModelDistributionNetwork.base_depth = 32
-ModelDistributionNetwork.latent1_deterministic = False
-ModelDistributionNetwork.latent2_deterministic = False
 ModelDistributionNetwork.kl_analytic = True
 ModelDistributionNetwork.latent1_size = 32
 ModelDistributionNetwork.latent2_size = 256


### PR DESCRIPTION
It looks like the `latent1_deterministic` and `latent2_deterministic` parameters should be removed in `slac.gin`. These parameters were removed from `ModelDistributionNetwork` in a previous commit, and I can't find any other references to them. Without making these changes, the example code doesn't run.